### PR TITLE
Fix mobile scroll progress bar issue

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1326,6 +1326,7 @@ html {
 /* --- Scroll Percentage Progress Bar --- */
 #scroll-progress {
     position: fixed;
+    top: 0;
     left: 0;
     height: 4px;
     width: 0%;

--- a/js/script.js
+++ b/js/script.js
@@ -511,13 +511,6 @@ function initScrollProgressBar() {
     const progressEl = document.getElementById('scroll-progress');
     if (!progressEl) return;
 
-    const navbar = document.querySelector('.navbar');
-
-    function updatePosition() {
-        const navHeight = navbar ? navbar.getBoundingClientRect().height : 0;
-        progressEl.style.top = navHeight + 'px';
-    }
-
     function updateBar() {
         const scrollTop = window.scrollY || document.documentElement.scrollTop;
         const docHeight = document.documentElement.scrollHeight - window.innerHeight;
@@ -525,23 +518,10 @@ function initScrollProgressBar() {
         progressEl.style.width = progress + '%';
     }
 
-    // Initial calculations
-    updatePosition();
+    // Initial calculation
     updateBar();
 
-    // Event listeners - update position on resize to account for navbar height changes
-    window.addEventListener('resize', () => {
-        updatePosition();
-        updateBar();
-    });
+    // Event listeners - only update the progress width
+    window.addEventListener('resize', updateBar);
     window.addEventListener('scroll', updateBar);
-    
-    // Also update position when navbar might change (e.g., mobile menu toggle)
-    const navbarToggler = document.querySelector('.navbar-toggler');
-    if (navbarToggler) {
-        navbarToggler.addEventListener('click', () => {
-            // Small delay to allow for any navbar height changes
-            setTimeout(updatePosition, 100);
-        });
-    }
 } 


### PR DESCRIPTION
Fix scroll progress bar appearing in the center of the screen on mobile.

The progress bar was incorrectly positioned due to JavaScript dynamically setting its `top` style based on the navbar height, which conflicted with its intended fixed position at the top of the viewport. This PR adds `top: 0` to the CSS and removes the problematic JavaScript positioning logic.